### PR TITLE
[FEATURE] Show toast notifications when HTTP requests fail

### DIFF
--- a/SELearning/Pages/CreateContent.razor
+++ b/SELearning/Pages/CreateContent.razor
@@ -6,6 +6,7 @@
 
 @inject HttpClient Http
 @inject IJSRuntime JsRuntime
+@inject ToastService service;
 
 <h1>Create Content</h1>
 <EditForm class="col-lg-12" Model="@Content" OnValidSubmit="@CreateContentAsync">
@@ -68,8 +69,8 @@
         [Required(AllowEmptyStrings = false)]
         public string SectionId { get; set; }
     }
-  
-    private SectionDto[] sections = {}; 
+
+    private SectionDto[] sections = { new SectionDto { Id = 1, Title = "Fancy section title" } }; 
     private ContentUserDTO Content { get; set; } = new();
     private bool? isPosted = null;
 
@@ -82,10 +83,12 @@
         } 
         catch(AccessTokenNotAvailableException exception)
         {
+            service.AddToast(ToastNotification.CreateNoAccessToastNotification());
             exception.Redirect();
         } 
         catch(Exception exception)
         {
+            service.AddToast(ToastNotification.CreateGenericErrorToastNotification(exception.Message));
             await this.Alert(exception);
         }
     }
@@ -104,6 +107,7 @@
         }
         catch (AccessTokenNotAvailableException exception)
         {
+            service.AddToast(ToastNotification.CreateNoAccessToastNotification());
             exception.Redirect();
         }
     }

--- a/SELearning/Shared/Toast/ToastNotification.cs
+++ b/SELearning/Shared/Toast/ToastNotification.cs
@@ -58,4 +58,11 @@ public partial class ToastNotification : IDisposable
     {
         _dismissTimer.Dispose();
     }
+
+    public static ToastNotification CreateNoAccessToastNotification() =>
+        new("Access not available!", "Unfortunately, our authorization handler was not able " +
+            "to find your access token. Please contact the admin", ToastType.Error, 10_000);
+
+    public static ToastNotification CreateGenericErrorToastNotification(string message) =>
+        new("Fatal error!", $"An error occurred: {message}", ToastType.Error, 10_000);
 }

--- a/SELearning/Shared/Toast/ToastWrapper.razor
+++ b/SELearning/Shared/Toast/ToastWrapper.razor
@@ -1,7 +1,7 @@
 @inject ToastService Service
 
 <div style="position: relative;">
-    <div style="position: absolute; top: 0; right: 0;width: 22rem;">
+    <div style="position: absolute; top: 0; right: 0; width: 22rem; z-index: 1">
         @foreach (var notification in _notifications)
         {
             <ToastNotificationComponent Notification="@notification" />


### PR DESCRIPTION
## Checklists
### Types of changes
<!-- Put an 'x' in the box(es) that apply. -->
- [ ] Fix (non-breaking change that fixes existing issue)
- [x] Feature (non-breaking change that adds a feature)
- [ ] Breaking change (fix or feature that breaks or removes other functionality)
<!-- If none of the above apply, please add another box that applies -->

### Pre-flight checklist
<!-- Before going further with this PR, please check the below checklist, and make sure you cover everything in it-->
- [ ] PR changes requires documentation change
  - [ ] I have updated the documentation accordingly
- [x] I have tested my change, and run all unit tests <!-- Further description required below -->
- [x] I ran ``dotnet format`` and committed+pushed the result

## Description
<!-- Clear and concise description of your changes -->
This PR adds toast notifications whenever an HTTP request fails. Currently, we only have two requests (both in the `CreateContent` Razor Page). Also makes toast notifications appear in front of the page (instead of behind something like a `Form`).

## Why
<!-- Why is this change necessary? What does it solve? -->
This will let the user know that an error has happened, such as the Authorization Handler failing to find an access token.

### Fixes issues:
<!-- If this PR fixes open issue(s) please link them here -->
<!-- If it doesn't, please open an issue and then link it here -->

## How has this been tested
<!-- If appropriate, describe your testing strategy for the code in this PR. -->
I manually threw exceptions to see if the toast notifications would appear when they were caught.
