### PR TITLE
Fix/any resource rule

### DIFF
--- a/SELearning.Core/Permission/Permission.cs
+++ b/SELearning.Core/Permission/Permission.cs
@@ -23,7 +23,5 @@ public enum Permission
 
 public static class PermissionExtensions
 {
-    // TODO: This is an UGLY hack. We need to refactor, but you know what they
-    // say: make it work, then refactor
     public static bool ActsOnAuthorOnly(this Permission perm) => Enum.GetName<Permission>(perm)!.Contains("Own");
 }

--- a/SELearning.Infrastructure/Authorization/Rules/AuthoredResourceRule.cs
+++ b/SELearning.Infrastructure/Authorization/Rules/AuthoredResourceRule.cs
@@ -15,9 +15,16 @@ public class AuthoredResourceRule : BaseResourceRule
         if (!IsEvaluateable(resource))
             return await Task.Run<bool>(() => false);
 
-        IAuthored authoredRessource = (IAuthored)resource;
+        IAuthored authoredResource = (IAuthored)resource;
         string userId = context.Get<string>("UserId");
+        int userCredibilityScore = context.Get<int>("UserCredibilityScore");
+        IReadOnlyDictionary<Permission, int> permissionCredScoreLevels = context.Get<IReadOnlyDictionary<Permission, int>>("RequiredCredibilityScores");
 
-        return userId == authoredRessource.Author.Id;
+        var isPermitted = permissionCredScoreLevels[permission] <= userCredibilityScore;
+        if (permission.ActsOnAuthorOnly())
+            isPermitted &= authoredResource.Author.Id == userId;
+
+
+        return isPermitted;
     }
 }


### PR DESCRIPTION
## Checklists
### Types of changes
<!-- Put an 'x' in the box(es) that apply. -->
- [x] Fix (non-breaking change that fixes existing issue)
- [ ] Feature (non-breaking change that adds a feature)
- [ ] Breaking change (fix or feature that breaks or removes other functionality)
<!-- If none of the above apply, please add another box that applies -->

### Pre-flight checklist
<!-- Before going further with this PR please check the below checklist, and make sure you cover everything in it-->
- [ ] PR changes requires documentation change
  - [ ] I have updated the documentation accordingly
- [x] I have tested my change, and run all unit tests <!-- Further description required below -->
- [x] I ran ``dotnet format`` and committed+pushed the result

## Description
<!-- Clear and concise description of your changes -->
Fixes the issue that if an any permission is evaluated then it checks if it is an author. Now it does not but only checks that the credibility score is higher